### PR TITLE
Add error-handeling to the parser

### DIFF
--- a/zhudi/processing.py
+++ b/zhudi/processing.py
@@ -119,7 +119,7 @@ class PreProcessing(object):
                         translation_file.write(translation_clean+"\n")
                     with open("pinyin", mode="a") as pinyin_file:
                         pinyin_file.write(clean_pinyin+"\n")
-            except IndexError as error:
+            except IndexError:
                 print("Warning: Could not parse the following line:")
                 print("\t'" + i + "'")
             except Exception as error:

--- a/zhudi/processing.py
+++ b/zhudi/processing.py
@@ -82,43 +82,50 @@ class PreProcessing(object):
             pinyin_delimiters = []
             translation_delimiters = []
             translation = []
+            try:
+                if len(i) > 9 and i[0] != "#":
+                    for k in range(len(i)):
+                        if i[k] == " ":  # look for spaces
+                            space_ind.append(k)
+                        if i[k] == "[":  # look for pinyin delimiters
+                            pinyin_delimiters.append(k)
+                        if i[k] == "]":
+                            pinyin_delimiters.append(k)
+                        if i[k] == "/":  # look for translation delimiters
+                            translation_delimiters.append(k)
+                    traditional = i[0:space_ind[0]]
+                    simplified = i[space_ind[0]+1:space_ind[1]]
+                    pinyin = i[pinyin_delimiters[0]+1:pinyin_delimiters[1]]
+                    for index in range(len(translation_delimiters) - 1):
+                        translation.append(i[translation_delimiters[index] + 1:translation_delimiters[index + 1]])
 
-            if i[0] != "#":
-                for k in range(len(i)):
-                    if i[k] == " ":  # look for spaces
-                        space_ind.append(k)
-                    if i[k] == "[":  # look for pinyin delimiters
-                        pinyin_delimiters.append(k)
-                    if i[k] == "]":
-                        pinyin_delimiters.append(k)
-                    if i[k] == "/":  # look for translation delimiters
-                        translation_delimiters.append(k)
-                traditional = i[0:space_ind[0]]
-                simplified = i[space_ind[0]+1:space_ind[1]]
-                pinyin = i[pinyin_delimiters[0]+1:pinyin_delimiters[1]]
-                for index in range(len(translation_delimiters) - 1):
-                    translation.append(i[translation_delimiters[index] + 1:translation_delimiters[index + 1]])
+                    clean_pinyin = unstick(pinyin)
+                    translation_clean = ""
+                    for i in range(len(translation)):
+                        if i != 0:
+                            translation_clean += "/"
+                        translation_clean += translation[i]
 
-                clean_pinyin = unstick(pinyin)
-                translation_clean = ""
-                for i in range(len(translation)):
-                    if i != 0:
-                        translation_clean += "/"
-                    translation_clean += translation[i]
+                    pinyin_list.append(clean_pinyin)
+                    traditional_list.append(traditional)
+                    simplified_list.append(simplified)
+                    translation_list.append(translation_clean)
 
-                pinyin_list.append(clean_pinyin)
-                traditional_list.append(traditional)
-                simplified_list.append(simplified)
-                translation_list.append(translation_clean)
-
-                with open("simplified", mode="a") as simplified_file:
-                    simplified_file.write(simplified+"\n")
-                with open("traditional", mode="a") as traditional_file:
-                    traditional_file.write(traditional+"\n")
-                with open("translation", mode="a") as translation_file:
-                    translation_file.write(translation_clean+"\n")
-                with open("pinyin", mode="a") as pinyin_file:
-                    pinyin_file.write(clean_pinyin+"\n")
+                    with open("simplified", mode="a") as simplified_file:
+                        simplified_file.write(simplified+"\n")
+                    with open("traditional", mode="a") as traditional_file:
+                        traditional_file.write(traditional+"\n")
+                    with open("translation", mode="a") as translation_file:
+                        translation_file.write(translation_clean+"\n")
+                    with open("pinyin", mode="a") as pinyin_file:
+                        pinyin_file.write(clean_pinyin+"\n")
+            except IndexError as error:
+                print("Warning: Could not parse the following line:")
+                print("\t'" + i + "'")
+            except Exception as error:
+                print("Error: An unknown error occurred while parsing the following line:")
+                print("\t'" + i + "'")
+                print(str(error))
 
         return (simplified_list, traditional_list, translation_list, pinyin_list)
     # End of split()

--- a/zhudi/processing.py
+++ b/zhudi/processing.py
@@ -83,7 +83,7 @@ class PreProcessing(object):
             translation_delimiters = []
             translation = []
             try:
-                if len(i) > 9 and i[0] != "#":
+                if i[0] != "#":
                     for k in range(len(i)):
                         if i[k] == " ":  # look for spaces
                             space_ind.append(k)


### PR DESCRIPTION
I tried to add the [handedict.u8 Dictionary](https://github.com/gugray/HanDeDict/blob/master/handedict.u8), but the following errror happend:

```
 zhudi -s handedict.u8                                                                                                                   
Splitting dictionary in progress…
Traceback (most recent call last):
  File "/usr/bin/zhudi_gui.py", line 45, in <module>
    main()
  File "/usr/bin/zhudi_gui.py", line 35, in main
    data_object = prepare_data(options)
  File "/usr/lib/python3.9/site-packages/zhudi/__init__.py", line 73, in prepare_data
    files = preproc_o.split(filename)
  File "/usr/lib/python3.9/site-packages/zhudi/processing.py", line 97, in split
    simplified = i[space_ind[0]+1:space_ind[1]]
IndexError: list index out of range
```

So I added the error handeling to the parser.

Now it looks like this:
```
 zhudi -s handedict.u8                                                                                                                   
Splitting dictionary in progress…
Warning: Could not parse the following line:
        '# ID-a00af3L
'

Pinyin to Zhuyin conversion in progress…
done.

```
