### PR TITLE
remove lock and improve scrolling

### DIFF
--- a/zhudi/gui.py
+++ b/zhudi/gui.py
@@ -46,15 +46,13 @@ class DictionaryWidgetMain(object):
         # Search field
         search_field = Gtk.Entry()
         search_field.set_visible(True)
-        search_field.connect("activate",
-                             lambda x: self.search_asked(search_field))
+        search_field.connect("activate", self.search_asked)
         search_field.set_placeholder_text("Looking for something?")
         self.search_field = search_field
 
         # Go, search! button
         go_button = Gtk.Button("Search")
-        go_button.connect("clicked",
-                          lambda x: self.search_asked(search_field))
+        go_button.connect("clicked", self.search_asked)
 
         # Search + button box
         sb_box = Gtk.Grid()
@@ -106,7 +104,7 @@ class DictionaryWidgetMain(object):
         self.translation_box.set_wrap_mode(Gtk.WrapMode.WORD)
 
         translation_scroll = Gtk.ScrolledWindow()
-        translation_scroll.add_with_viewport(self.translation_box)
+        translation_scroll.add(self.translation_box)
 
         frame_translation = Gtk.Frame()
         frame_translation.set_label_widget(translation_label)
@@ -135,23 +133,24 @@ class DictionaryWidgetMain(object):
         horizontal_box.set_row_homogeneous(True)
         return horizontal_box
 
-    def search_asked(self, searchfield):
+    def search_asked(self, search_field):
         """ Start search when users hit ENTER or the search button. """
-        searchfield.grab_focus()
-        text = searchfield.get_text()
+        search_field.grab_focus()
+        text = search_field.get_text()
+        DICTIONARY_TOOLS_OBJECT.reset_search()
         if text == "":
-            DICTIONARY_TOOLS_OBJECT.index = []
             self.results_list.clear()
             self.display_translation(0)
         else:
             self.language = self.determine_language(text)
             if self.language == "Latin":
-                given_list = self.data_object.translation
+                DICTIONARY_TOOLS_OBJECT.search(self.data_object.translation, text)
+                DICTIONARY_TOOLS_OBJECT.search(self.data_object.pinyin, text)
             elif self.data_object.hanzi == "Traditional":
-                given_list = self.data_object.traditional
+                DICTIONARY_TOOLS_OBJECT.search(self.data_object.traditional, text)
             else:
-                given_list = self.data_object.simplified
-            DICTIONARY_TOOLS_OBJECT.search(given_list, text)
+                DICTIONARY_TOOLS_OBJECT.search(self.data_object.simplified, text)
+            DICTIONARY_TOOLS_OBJECT.finish_search(self.data_object)
             self.update_results()
             self.results_tree.grab_focus()
             self.display_translation(0)
@@ -207,7 +206,7 @@ class DictionaryWidgetMain(object):
             string = string + trans[i] + "\n"
 
         # Add [] arround the pronounciation parts
-        p_string = romanisation_dic[index].split()
+        p_string = romanisation_dic[index].split('/', 1)[0].split()
         pronounciation_string = []
         for point in range(len(p_string)):
             if self.data_object.romanisation == "pinyin":
@@ -386,7 +385,7 @@ class SegmentationWidget(object):
         results_scroll = Gtk.ScrolledWindow()
         # No horizontal bar, automatic vertical bar
         results_scroll.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
-        results_scroll.add_with_viewport(results_tree)
+        results_scroll.add(results_tree)
 
         self.frame_results = Gtk.Frame()
         self.frame_results.add(results_scroll)
@@ -414,7 +413,7 @@ class SegmentationWidget(object):
         self.results_field.set_wrap_mode(Gtk.WrapMode.WORD)
 
         self.results_scroll = Gtk.ScrolledWindow()
-        self.results_scroll.add_with_viewport(self.results_field)
+        self.results_scroll.add(self.results_field)
 
         self.results_frame = Gtk.Frame()
         self.results_frame.set_label_widget(self.results_label)
@@ -497,7 +496,7 @@ class SegmentationWidget(object):
             string = string + trans[local_index] + "\n"
 
         # Add [] arround the pronounciation parts
-        p_string = romanisation_dic[index].split()
+        p_string = romanisation_dic[index].split('/', 1)[0].split()
         pronounciation_string = []
         for point in range(len(p_string)):
             if self.data_object.romanisation == "pinyin":

--- a/zhudi/gui.py
+++ b/zhudi/gui.py
@@ -153,6 +153,7 @@ class DictionaryWidgetMain(object):
                 given_list = self.data_object.simplified
             DICTIONARY_TOOLS_OBJECT.search(given_list, text)
             self.update_results()
+            self.results_tree.grab_focus()
             self.display_translation(0)
         self.results_tree.scroll_to_cell([0])
     # end of search_asked
@@ -750,11 +751,15 @@ class MainWindow(object):
         return SegmentationWidget(self.data_object).build()
 
     def on_key_press(self, widget, event, data=None):
-        if self.tab_box.get_current_page() == 0 and not self.dict_settings.search_field.has_focus() and event.keyval not in {Gdk.KEY_Up, Gdk.KEY_Down}:
-            if event.keyval == Gdk.KEY_Left or event.keyval == Gdk.KEY_Right:
-                self.dict_settings.search_field.grab_focus_without_selecting()
-            else:
-                self.dict_settings.search_field.grab_focus()
+        if self.tab_box.get_current_page() == 0:
+            is_nav_key = event.keyval in {Gdk.KEY_Up, Gdk.KEY_Down, Gdk.KEY_Page_Up, Gdk.KEY_Page_Down}
+            if not self.dict_settings.search_field.has_focus() and not is_nav_key:
+                if event.keyval == Gdk.KEY_Left or event.keyval == Gdk.KEY_Right:
+                    self.dict_settings.search_field.grab_focus_without_selecting()
+                else:
+                    self.dict_settings.search_field.grab_focus()
+            elif is_nav_key:
+                self.dict_settings.results_tree.grab_focus()
 
     @staticmethod
     def on_key_release(widget, event, data=None):

--- a/zhudi/gui.py
+++ b/zhudi/gui.py
@@ -250,7 +250,6 @@ class DictionaryWidgetMain(object):
                                     "Wubi86 (五筆86): \n" + wubi86_code)
         bold = translation_buffer.create_tag(weight=Pango.Weight.BOLD)
         big = translation_buffer.create_tag(size=30 * Pango.SCALE)
-        medium = translation_buffer.create_tag(size=15 * Pango.SCALE)
         blue = translation_buffer.create_tag(foreground="#268bd2")
 
         # "Chinese" in bold
@@ -276,7 +275,6 @@ class DictionaryWidgetMain(object):
         end_3 = translation_buffer.get_iter_at_line(5)
         end_3.forward_to_line_end()
         translation_buffer.apply_tag(blue, start_3, end_3)
-        translation_buffer.apply_tag(medium, start_3, end_3)
 
         # "Meaning" in bold
         start_3 = translation_buffer.get_iter_at_line(7)
@@ -542,7 +540,6 @@ class SegmentationWidget(object):
                                     "Wubi86 (五筆86): \n" + wubi86_code)
         bold = translation_buffer.create_tag(weight=Pango.Weight.BOLD)
         big = translation_buffer.create_tag(size=30*Pango.SCALE)
-        medium = translation_buffer.create_tag(size=15*Pango.SCALE)
         blue = translation_buffer.create_tag(foreground="#268bd2")
 
         # "Chinese" in bold
@@ -568,7 +565,6 @@ class SegmentationWidget(object):
         end_3 = translation_buffer.get_iter_at_line(5)
         end_3.forward_to_line_end()
         translation_buffer.apply_tag(blue, start_3, end_3)
-        translation_buffer.apply_tag(medium, start_3, end_3)
 
         # "Meaning" in bold
         start_3 = translation_buffer.get_iter_at_line(7)
@@ -692,6 +688,7 @@ class MainWindow(object):
         self.window.set_default_size(700, 500)
         self.window.set_title("Zhudi")
         self.window.set_position(Gtk.WindowPosition.CENTER)
+        self.window.modify_font(Pango.FontDescription('20'))
         self.window.connect("key-press-event", self.on_key_press)
         self.window.connect("key-release-event", self.on_key_release)
         self.data_object = data_object

--- a/zhudi/gui.py
+++ b/zhudi/gui.py
@@ -34,7 +34,6 @@ class DictionaryWidgetMain(object):
         self.data_object = data_object
         self.language = ""
         self.results_list = []
-        self.lock = False
         self.search_field = None
         self.translation_box = None
 
@@ -86,7 +85,7 @@ class DictionaryWidgetMain(object):
         results_scroll = Gtk.ScrolledWindow()
         # No horizontal bar, automatic vertical bar
         results_scroll.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
-        results_scroll.add_with_viewport(results_tree)
+        results_scroll.add(results_tree)
 
         frame_results = Gtk.Frame()
         frame_results.add(results_scroll)
@@ -138,12 +137,10 @@ class DictionaryWidgetMain(object):
         """ Start search when users hit ENTER or the search button. """
         text = searchfield.get_text()
         if text == "":
-            self.lock = True
             DICTIONARY_TOOLS_OBJECT.index = []
             self.results_list.clear()
             self.display_translation(0)
         else:
-            self.lock = False
             self.language = self.determine_language(text)
             if self.language == "Latin":
                 given_list = self.data_object.translation
@@ -312,10 +309,9 @@ class DictionaryWidgetMain(object):
 
     def display_another_result(self, selection):
         """ Display the newly selected result. """
-        if not self.lock:
-            model, treeiter = selection.get_selected()
-            if treeiter is not None:
-                self.display_translation(model[treeiter].path[0])
+        model, treeiter = selection.get_selected()
+        if treeiter is not None:
+            self.display_translation(model[treeiter].path[0])
 
 
 class SegmentationWidget(object):

--- a/zhudi/gui.py
+++ b/zhudi/gui.py
@@ -34,6 +34,7 @@ class DictionaryWidgetMain(object):
         self.data_object = data_object
         self.language = ""
         self.results_list = []
+        self.results_tree = None
         self.search_field = None
         self.translation_box = None
 
@@ -79,6 +80,7 @@ class DictionaryWidgetMain(object):
         results_tree.set_enable_search(False)
         results_tree.tvcolumn.set_sort_column_id(-1)
         results_tree.set_reorderable(False)
+        self.results_tree = results_tree
         select = results_tree.get_selection()
         select.connect("changed", self.display_another_result)
 
@@ -135,6 +137,7 @@ class DictionaryWidgetMain(object):
 
     def search_asked(self, searchfield):
         """ Start search when users hit ENTER or the search button. """
+        searchfield.grab_focus()
         text = searchfield.get_text()
         if text == "":
             DICTIONARY_TOOLS_OBJECT.index = []
@@ -151,6 +154,7 @@ class DictionaryWidgetMain(object):
             DICTIONARY_TOOLS_OBJECT.search(given_list, text)
             self.update_results()
             self.display_translation(0)
+        self.results_tree.scroll_to_cell([0])
     # end of search_asked
 
     @staticmethod

--- a/zhudi/processing.py
+++ b/zhudi/processing.py
@@ -143,7 +143,7 @@ class PreProcessing(object):
 
         try:
             pinyin_file = open(pinyin_file_name, "r")
-            pinyin = pinyin_file.readlines()
+            pinyin = [p + '/' + p.replace(' ', '') + '/' + re.sub(r'[ \d]', '', p) for p in pinyin_file.readlines()]
             pinyin_file.close()
             zhuyin_file = open(zhuyin_file_name, "r")
             zhuyin = zhuyin_file.readlines()
@@ -377,6 +377,12 @@ class DictionaryTools(object):
         else:
             return pin1yin1
 
+    def reset_search(self):
+        self.index = []
+
+    def finish_search(self, data_object):
+        self.index = sorted(set(self.index), key=lambda x: (len(data_object.traditional[x]), data_object.traditional[x]))[:500]
+
     def search(self, given_list, text):
         """ Search for a string in a list.
 
@@ -390,20 +396,12 @@ class DictionaryTools(object):
         """
         words = (text.lower()).split()
         index = []
-        total = []
         # try in each line of the dic
         for line in range(len(given_list)):
             counter = 0
-            for word_token in range(len(words)):
-                # for each word of the request (case insensitive)
-                if (given_list[line].lower()).count(words[word_token]) != 0:
-                    counter += 1
-                if counter == len(words):
-                    # only accepts lines containing every words
-                    index.append(line)
-                    total.append(len(given_list[line]))
-            if len(total) >= 500:
-                break
-        dico = dict(zip(index, total))
-        dico_sorted = sorted(dico.items(), key=lambda x: x[1])
-        self.index = [value[0] for value in dico_sorted[:]]
+            to_search = given_list[line].lower()
+            # for each word of the request (case insensitive)
+            # only accepts lines containing every words
+            if all(word in to_search for word in words):
+                index.append(line)
+        self.index.extend(index)


### PR DESCRIPTION
 - make all fonts bigger, now everything is size 20. This might be controversial :P it also makes the window bigger but I'm not sure why.
 - the window now follows the scrolling around after changing `add_with_viewport` to just `add`. This fixes https://github.com/Jiehong/Zhudi/issues/15
 - on search, scroll to top and highlight search text
 - remove `lock`, which is only used to not show the translation if the search field is empty. However, in this case the same code works as there is one result showing "no results"
 - can now search with pinyin with and without numbers (fixes https://github.com/Jiehong/Zhudi/issues/16)
 - all searches are ordered consistently by length of the chinese (fixes https://github.com/Jiehong/Zhudi/issues/14)